### PR TITLE
Add stddef.h in header file

### DIFF
--- a/ee24.h
+++ b/ee24.h
@@ -22,6 +22,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h>
 #include "ee24Config.h"
 
 bool    ee24_isConnected(void);


### PR DESCRIPTION
Hi!  **size_t** is declared in **stddef.h**
I am added

`#include <stddef.h>`

on you header file.